### PR TITLE
Fix sidebar display bug on mobile devices

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -247,6 +247,7 @@
     bottom: 0;
     padding: 20px;
     background-color: white;
+    z-index: 1;
   }
   .main {
     padding: 20px;


### PR DESCRIPTION
Fix the display bug on mobile devices that the code blocks will be on the top of the sidebar.
![657533816350978548](https://cloud.githubusercontent.com/assets/7052824/21149694/68bd132a-c12a-11e6-9a87-b6f6edae82a7.png)
