### PR TITLE
add chalk dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "element-closest": "^2.0.2",
+    "chalk": "^1.1.3",
     "highlight.js": "^9.8.0",
     "isomorphic-fetch": "^2.2.1",
     "jump.js": "^1.0.1",


### PR DESCRIPTION
Mac 10.12.1

```
$ node --version
v4.0.0

$ npm --version
2.14.2

$ docute init ./docs
module.js:338
    throw err;
    ^

Error: Cannot find module 'chalk'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/docute-cli/dist/bin/docute-init:69:14)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:475:10)
```