### PR TITLE
Simplify home layout

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -225,6 +225,7 @@
     margin: 0 auto;
     padding: 20px 0;
     background-color: white;
+    max-width: 1000px;
     min-height: 100vmin;
   }
   .content {
@@ -240,7 +241,6 @@
     .no-sidebar {
       .main {
         padding-bottom: 50px;
-        max-width: 900px;
         border: 1px solid rgba(0,0,0,.07);
         border-top: none;
         border-radius: 0 0 4px 4px;
@@ -275,15 +275,6 @@
       transition: transform .3s cubic-bezier(0.4, 0, 0, 1);
       &.visible {
         transform: translateX(0);
-      }
-    }
-  }
-  @media screen and (min-width: 1280px) {
-    .main {
-      max-width: 1000px;
-
-      .no-sidebar & {
-        max-width: 80%;
       }
     }
   }


### PR DESCRIPTION
Sorry for bothering again but #23 was merged much faster than I'd thought XDDD

I removed the breakpoint and add `max-width: 1000px` directly in `.main` element, too many conditions cause code confusing, so why not make things simple but great 😆.

PS: applying `max-width` directly does the same with the breakpoint, because `280px + 1000px = 1280px`.

PSS: changing width when sidebar collapsed is considered not good as it may change previous scrolling position.