### PR TITLE
Enable momentum scrolling on iOS

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -363,6 +363,10 @@
       box-shadow: 0 0 10px rgba(0,0,0,0.2);
       transform: translateX(-120%);
       transition: transform .3s cubic-bezier(0.4, 0, 0, 1);
+      /* Enable scroll with momentum on iOS devices */
+      overflow-y: scroll;
+      -webkit-overflow-scrolling: touch;
+
       &.visible {
         transform: translateX(0);
       }


### PR DESCRIPTION
Currently, the sidebar menu feels very sluggish to scroll on iOS devices due to the lack of "momentum scroll" support. This commits should fix this issue.