### PR TITLE
Center the mobile header vertically

### DIFF
--- a/src/components/MobileHeader.vue
+++ b/src/components/MobileHeader.vue
@@ -85,6 +85,7 @@
       font-weight: 300;
       font-size: 20px;
       display: flex;
+      align-items: center;
     }
 
     .header-left {
@@ -93,7 +94,6 @@
       .svg-icon {
         margin-right: 10px;
         color: #999;
-        margin-top: 1px;
         width: 24px;
       }
     }


### PR DESCRIPTION
This commit should properly center the header items on mobile.

Before:
![image](https://cloud.githubusercontent.com/assets/8056274/23493178/cbfc6528-ff44-11e6-9ff9-203f6dd302f0.png)

After:
![image](https://cloud.githubusercontent.com/assets/8056274/23493193/df81a02c-ff44-11e6-95fa-6dc105eaab09.png)
