### PR TITLE
feat(DocSearch): search as you type

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -9,7 +9,7 @@
       v-model="keyword"
       @focus="toggleFocus"
       @blur="toggleFocus"
-      @keydown.enter="handleSearch(keyword)">
+      @input="handleSearch(keyword)">
     <svg-icon name="close" class="svg-icon close" v-if="keyword" @click="handleClear"></svg-icon>
     <svg-icon name="search" class="svg-icon do-search" v-else @click="handleSearch(keyword)"></svg-icon>
   </div>
@@ -23,7 +23,8 @@
     data() {
       return {
         keyword: this.$route.query.keyword || '',
-        focus: false
+        focus: false,
+        debouncedURLChange: setTimeout(() => {}, 0),
       }
     },
     mounted() {
@@ -38,14 +39,16 @@
     methods: {
       ...mapActions(['search', 'updateSearchKeyword', 'searchReset']),
       handleSearch(keyword) {
-        if (keyword === this.$route.query.keyword) {
-          // when keyword is already the same as in url query
-          this.search(keyword)
-        } else {
-          // otherwise update url query
-          this.$router.push({ query: { ...this.$route.query, keyword } })
-          this.search(keyword)
+        clearTimeout(this.debouncedURLChange);
+
+        if (keyword !== this.$route.query.keyword) {
+          // update the url if there wasn't a new search in the last 700ms
+          this.debouncedURLChange = setTimeout(() => {
+            this.$router.push({ query: { ...this.$route.query, keyword } });
+          }, 700);
         }
+
+        this.search(keyword);
       },
       toggleFocus() {
         this.focus = !this.focus

--- a/src/plugins/docsearch/Logo.vue
+++ b/src/plugins/docsearch/Logo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="dosearch-logo inner-x" v-if="showLogo">
     <a href="https://www.algolia.com/docsearch" target="_blank">
-      <img src="https://www.algolia.com/static_assets/images/press/downloads/powered-by-algolia.png" alt="algolia" width="100">
+      <img src="https://www.algolia.com/static_assets/images/press/downloads/search-by-algolia.svg" alt="algolia" width="100">
     </a>
   </div>
 </template>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,7 +3,6 @@ import Vuex from 'vuex'
 import defined from 'defined'
 import { isType } from 'utils'
 import jump from 'utils/jump'
-import nprogress from 'nprogress'
 import event from 'utils/event'
 
 Vue.use(Vuex)
@@ -148,12 +147,10 @@ const store = new Vuex.Store({
       }, 400))
     },
     startSearching({ commit }) {
-      nprogress.start()
       commit('START_SEARCHING')
       event.emit('search:started')
     },
     stopSearching({ commit }, payload) {
-      nprogress.done()
       commit('STOP_SEARCHING', payload)
       event.emit('search:stopped', payload)
     },


### PR DESCRIPTION
Algolia offers DocSearch for free without any limits on the amount of operations, so offering search as you type is actually a better experience.

Because updating the URL on every keypress is actually a more expensive operation than actually doing the search, I delayed that by 700ms after the last keypress.

Meanwhile I also updated the Algolia logo to be the newer logo.

Something negative about this change could be that the 'loading' bar now goes at every keypress, Is there some way to delay that, or maybe disable all together for the dispatching of SearchDone? I couldn't immediately figure out what part of the code was responsibe

cc @ElPicador

gif that says more than words (the logo was updated after this recording):

![2017-04-14 18_23_02](https://cloud.githubusercontent.com/assets/6270048/25048962/8ca0f5d4-213f-11e7-97aa-c4e76488c999.gif)
