### PR TITLE
Support passing url to repo

### DIFF
--- a/src/views/Page.vue
+++ b/src/views/Page.vue
@@ -143,8 +143,9 @@
             })
           }
           if (repo) {
+            const isUrl = /^((http|https):\/\/)/.test(repo)
             defaultIcons.push({
-              link: `https://github.com/${repo}`,
+              link: isUrl ? repo : `https://github.com/${repo}`,
               label: 'Star me on GitHub',
               icon: 'github'
             })


### PR DESCRIPTION
Currently docute assumes the repo (github) link is a public github url, which starts with `https://github.com`. However, I would like to be able to use a corporate github url as well, which has a different hostname. So I made this small change to allow passing url as github repo link, in addition to `'username/project'`.