### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ Authored and maintained by EGOIST with help from contributors ([list](https://gi
 
 > [egoistian.com](https://egoistian.com) · GitHub [@egoist](https://github.com/egoist) · Twitter [@_egoistlily](https://twitter.com/_egoistlily)
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/Ux4hdW1RzN8XpYzVUoWJFxg9/egoist/docute'>  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/Ux4hdW1RzN8XpYzVUoWJFxg9/egoist/docute.svg' /></a>
+


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8