### PR TITLE
feat: dynamic source with getSource option

### DIFF
--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -107,12 +107,20 @@ export default {
     },
 
     async renderPath(route) {
-      let filepath = `${this.siteConfig.sourceRoot}${route.params[0]}`
-      const endsWithSlash = /\/$/.test(filepath)
-      if (endsWithSlash) {
-        filepath += this.siteConfig.indexFile
-      } else {
-        filepath += '.md'
+      let filepath
+
+      if (typeof this.siteConfig.getSource === 'function') {
+        filepath = this.siteConfig.getSource(route)
+      }
+
+      if (!filepath) {
+        filepath = `${this.siteConfig.sourceRoot}${route.params[0]}`
+        const endsWithSlash = /\/$/.test(filepath)
+        if (endsWithSlash) {
+          filepath += this.siteConfig.indexFile
+        } else {
+          filepath += '.md'
+        }
       }
 
       progress.start()

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -54,6 +54,29 @@ The root path to fetch sources (Markdown files) from.
 
 For example, for path `/guide/hello` we will fetch `sourceRoot + 'guide/hello.md'` which is `/guide/hello.md` by default.
 
+### getSource
+
+- __Type__: `function(route: Route)`
+
+You can provide `getSource` for a custom path to source mapping for all or specific routes.
+
+If a falsy value is returned the fucntion will be ignored and default mapping will be applied.
+
+**Example:**
+
+```js
+const routes = {
+    '/docute-master': 'https://raw.githubusercontent.com/egoist/docute/master/README.md',
+}
+
+const doc = new Docute({
+    getSource: function (route) {
+        return routes[route.path]
+    },
+}
+```
+
+
 ### sidebar
 
 - __Type__: `SidebarItem[]`


### PR DESCRIPTION
With v3, we had a really useful option for specifying the source of MD files using `source` key. It seems v4 is a rewrite without this ability, so I've proposed a simple option to allow a dynamic route to source mappings.