### PR TITLE
#212 apply decoded uri for getting $route's path and hash

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -133,7 +133,7 @@ export default {
     },
 
     jumpToHash() {
-      const {hash} = this.$route
+      const hash = decodeURI(this.$route.hash)
       if (hash) {
         const el = document.querySelector(hash)
         if (el) {


### PR DESCRIPTION
For solving encoded uri not recognize by vue, I added decoded uri computed property inside home.vue

The reason I didn't use decodeURIComponent() function is vue router component guard function's `to` object has no encoded special character it's fullpath url.

Maybe there's a way passing component props through router beforeEach(), but I didn't because It's not simple.

Thanks and Regards