### PR TITLE
docs: fix navbar links document

### DIFF
--- a/website/docs/options.md
+++ b/website/docs/options.md
@@ -31,7 +31,7 @@ interface NavItem {
   title: string
   link?: string
   // Use `links` instead of `link` to display dropdown
-  links?: Array<NavItemLink>
+  children?: Array<NavItemLink>
 }
 
 interface NavItemLink {

--- a/website/docs/options.md
+++ b/website/docs/options.md
@@ -30,7 +30,7 @@ An array of navigation items to display at navbar.
 interface NavItem {
   title: string
   link?: string
-  // Use `links` instead of `link` to display dropdown
+  // Or use `children` to display dropdown menu
   children?: Array<NavItemLink>
 }
 


### PR DESCRIPTION
## Problem
In document, it said that:

```typescript
interface NavItem {
  title: string
  link?: string
  // Use `links` instead of `link` to display dropdown
  links?: Array<NavItemLink>
}

interface NavItemLink {
  title: string
  link: string
}
```

but in code, it used `item.children` instead of `item.links`

## Solution

Change `item.children` to `item.links`