### PR TITLE
feat: use children in sidebar

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -91,7 +91,7 @@ export default {
     },
     getChildren(item) {
       // backward compabillity
-      return item.children ? item.children : item.links
+      return item.children || item.links
     }
   }
 }

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -17,7 +17,7 @@
         :key="index"
       >
         <div class="ItemTitle" v-if="item.title">{{ item.title }}</div>
-        <template v-for="(link, index) of item.links">
+        <template v-for="(link, index) of getChildren(item)">
           <a
             v-if="isExternalLink(link.link)"
             :key="index"
@@ -88,6 +88,10 @@ export default {
       const filename = getFilenameByPath(path)
       const fileUrl = getFileUrl(sourcePath, filename)
       return fileUrl ? [fileUrl] : []
+    },
+    getChildren(item) {
+      // backward compabillity
+      return item.children ? item.children : item.links
     }
   }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -201,7 +201,9 @@ const store = new Vuex.Store({
       return sidebar
         ? sidebar
             .reduce((res, next) => {
-              return [...res, ...next.links]
+              // backward compabillity
+              const children = next.children ? next.children : next.links || []
+              return [...res, ...children]
             }, [])
             .filter(item => {
               return !isExternalLink(item.link)

--- a/src/store.js
+++ b/src/store.js
@@ -202,7 +202,7 @@ const store = new Vuex.Store({
         ? sidebar
             .reduce((res, next) => {
               // backward compabillity
-              const children = next.children ? next.children : next.links || []
+              const children = next.children || next.links || []
               return [...res, ...children]
             }, [])
             .filter(item => {

--- a/website/docs/guide/customization.md
+++ b/website/docs/guide/customization.md
@@ -47,10 +47,10 @@ Sidebar is mainly used for navigations between pages. As you can see from this p
 ```js
 new Docute({
   sidebar: [
-    // A sidebar item, with multiple sub-links
+    // A sidebar item, with child links
     {
       title: 'Guide', // Optional
-      links: [
+      children: [
         {
           title: 'Getting Started',
           link: '/guide/getting-started'

--- a/website/docs/guide/internationalization.md
+++ b/website/docs/guide/internationalization.md
@@ -23,7 +23,7 @@ Then you can use the `overrides` option to localize the text used in UI:
 new Docute({
   sidebar: [
     {
-      links: [
+      children: [
         { title: 'Guide', link: '/guide' }
       ]
     }
@@ -37,7 +37,7 @@ new Docute({
       // Override the default sidebar
       sidebar: [
         {
-          links: [
+          children: [
             { title: '指南', link: '/zh/guide' }
           ]
         }

--- a/website/docs/options.md
+++ b/website/docs/options.md
@@ -49,7 +49,7 @@ An array of navigation items to display at sidebar.
 ```ts
 interface SidebarItem {
   title?: string
-  links: Array<SidebarItemLink>
+  children: Array<SidebarItemLink>
 }
 
 interface SidebarItemLink {

--- a/website/docs/zh/guide/customization.md
+++ b/website/docs/zh/guide/customization.md
@@ -47,7 +47,7 @@ new Docute({
   sidebar: [
     {
       title: 'Guide', // 可选的
-      links: [
+      children: [
         {
           title: 'Getting Started',
           link: '/guide/getting-started'

--- a/website/docs/zh/guide/internationalization.md
+++ b/website/docs/zh/guide/internationalization.md
@@ -23,7 +23,7 @@ docs
 new Docute({
   sidebar: [
     {
-      links: [
+      children: [
         { title: 'Guide', link: '/guide' }
       ]
     }
@@ -37,7 +37,7 @@ new Docute({
       // Override the default sidebar
       sidebar: [
         {
-          links: [
+          children: [
             { title: '指南', link: '/zh/guide' }
           ]
         }

--- a/website/docs/zh/options.md
+++ b/website/docs/zh/options.md
@@ -50,7 +50,7 @@ interface NavItemLink {
 ```ts
 interface SidebarItem {
   title?: string
-  links: Array<ItemLink>
+  children: Array<ItemLink>
 }
 
 interface ItemLink {

--- a/website/index.js
+++ b/website/index.js
@@ -106,7 +106,7 @@ new Docute({
   sidebar: [
     {
       title: 'Guide',
-      links: [
+      children: [
         {
           title: 'Customization',
           link: '/guide/customization'
@@ -135,7 +135,7 @@ new Docute({
     },
     {
       title: 'Advanced',
-      links: [
+      children: [
         {
           title: 'Use With Bundlers',
           link: '/guide/use-with-bundlers'
@@ -148,7 +148,7 @@ new Docute({
     },
     {
       title: 'References',
-      links: [
+      children: [
         {
           title: 'Options',
           link: '/options'
@@ -165,7 +165,7 @@ new Docute({
     },
     {
       title: 'Misc',
-      links: [
+      children: [
         {
           title: 'Credits',
           link: '/credits'
@@ -193,7 +193,7 @@ new Docute({
       sidebar: [
         {
           title: '指南',
-          links: [
+          children: [
             {
               title: '自定义',
               link: '/zh/guide/customization'
@@ -222,7 +222,7 @@ new Docute({
         },
         {
           title: '进阶',
-          links: [
+          children: [
             {
               title: '使用打包工具',
               link: '/zh/guide/use-with-bundlers'
@@ -235,7 +235,7 @@ new Docute({
         },
         {
           title: '参考',
-          links: [
+          children: [
             {
               title: '配置项',
               link: '/zh/options'
@@ -252,7 +252,7 @@ new Docute({
         },
         {
           title: '其它',
-          links: [
+          children: [
             {
               title: '致谢',
               link: '/zh/credits'


### PR DESCRIPTION
As the discussion in https://github.com/egoist/docute/pull/221, use `children` in sidebar for consistency with HeaderNav.

@egoist Please help to review it when you're available.