### PR TITLE
embeds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import versionsPlugin from './plugins/versions'
 import bannerFooter from './plugins/banner-footer'
 import darkThemeToggler from './plugins/dark-theme-toggler'
 import searchPlugin from './plugins/search'
+import embedPlugin from './plugins/embed'
 
 Vue.component(ImageZoom.name, ImageZoom)
 Vue.component(Badge.name, Badge)
@@ -55,6 +56,7 @@ class Docute {
     })
 
     const plugins = [
+      embedPlugin,
       i18nPlugin,
       evaluateContentPlugin,
       versionsPlugin,

--- a/src/plugins/embed/index.js
+++ b/src/plugins/embed/index.js
@@ -1,0 +1,75 @@
+import {getFilenameByPath, getFileUrl, isExternalLink} from '../../utils'
+import inlineRender from '../../utils/inlineRender'
+
+const SCAN = /#embed\(.*?\)(?!`)/g
+
+async function getFile(url, api, type) {
+  if (!isExternalLink(url)) {
+    let filename = getFilenameByPath(url)
+    if (type) {
+      filename = filename.replace('.md', '')
+    }
+    const file = getFileUrl(api.store.getters.config.sourcePath, filename)
+    const res = await fetch(file)
+    return res.text()
+  }
+  return url
+}
+
+function compileMedia(type, url, api, codeType = '', ...args) {
+  const attributes = args ? args[0].join(' ') : ''
+  const overRideAttrs = String(codeType) + ' ' + attributes
+
+  switch (type) {
+    case 'fragment':
+      return getFile(url, api).then(inlineRender)
+    case 'iframe':
+      return `<iframe src="${url}" width=100% height=400 ${overRideAttrs}></iframe>`
+    case 'video':
+      return `<video src="${url}" controls width=100% ${overRideAttrs}>Outdated browser version, no video</video>`
+    case 'audio':
+      return `<audio src="${url}" controls ${overRideAttrs}>Outdated browser version, no audio</audio>`
+    case 'code':
+      return getFile(url, api, type)
+        .then(x => `\`\`\`${codeType}\n${x}\n\`\`\``)
+        .then(inlineRender)
+    default:
+      return <h1>Missing embed kind</h1>
+  }
+}
+
+async function replaceAsync(str, regex, asyncFn) {
+  const promises = []
+  str.replace(regex, (match, ...args) => {
+    const promise = asyncFn(match, ...args)
+    promises.push(promise)
+  })
+  const data = await Promise.all(promises)
+  return str.replace(regex, () => data.shift())
+}
+
+function transformEmbeds(markdown, api) {
+  function process(match) {
+    const params = match
+      .replace('#embed(', '')
+      .replace(')', '')
+      .split(' ')
+    const href = params[0]
+    const type = params[1]
+    const codeType = params[2]
+    const embed = compileMedia(type, href, api, codeType, params.slice(3))
+    return embed
+  }
+  return replaceAsync(markdown, SCAN, process)
+}
+
+const embedPlugin = {
+  name: 'embed',
+  extend(api) {
+    api.processMarkdown(async markdown => {
+      return transformEmbeds(markdown, api)
+    })
+  }
+}
+
+export default embedPlugin

--- a/src/utils/inlineRender.js
+++ b/src/utils/inlineRender.js
@@ -1,0 +1,22 @@
+import hooks from '../hooks'
+import markedRenderer from './markedRenderer'
+import marked from './marked'
+import highlight from './highlight'
+
+async function inlineRender(iContent) {
+  let content = await hooks.processPromise('processMarkdown', iContent)
+  const env = {
+    headings: [],
+    mixins: [],
+    config: {}
+  }
+  content = marked(content, {
+    renderer: markedRenderer(hooks),
+    highlight,
+    env
+  })
+  content = await hooks.processPromise('processHTML', content)
+  return content
+}
+
+export default inlineRender

--- a/website/docs/exampleEmbeds/embedjs.js
+++ b/website/docs/exampleEmbeds/embedjs.js
@@ -1,0 +1,2 @@
+const a = 1
+const b = a? a: 0

--- a/website/docs/exampleEmbeds/fragment.md
+++ b/website/docs/exampleEmbeds/fragment.md
@@ -1,0 +1,3 @@
+### Title from fragment
+
+*fragment body*

--- a/website/docs/guide/embed.md
+++ b/website/docs/guide/embed.md
@@ -1,0 +1,30 @@
+# Embed
+
+Embeds let you display items from different files or websites that you would use in multiple places but would rather not edit them there (a single file to edit, many places to show), or media files that markdown doesn't handle. The general syntax for embed is `#embed(absoluteUrl embedKind codeTypeOrHTMLAttributes)`. Embed kind is a video, audio, iframe, code, or fragment. Absolute path is something like `/exampleEmbeds/embedjs.js` or `https://cinwell.com`. In order to pass additional or overriding attributes for properties like width, height, or media options for audio/video add arguments at the end `#embed(https://cinwell.com iframe width=autho height=100)`.
+
+## Demonstrations
+Some of these describe defaults, and caveats.
+
+### Code
+
+#embed(/exampleEmbeds/embedjs.js code js)
+
+### Fragment
+Note that the titles from fragment aren't visible in sidebar. Titles of second and third level are suppose to be shown there with the first level used as browser tab title.
+
+#embed(/exampleEmbeds/fragment.md fragment)
+
+### iFrame
+iFrame loads a website, or widget in separate window. Youtube vidoes for example load through iFrame on a non-native website. The defaults are width 100%, and height 400 pixels.
+
+#embed(https://cinwell.com iframe)
+
+### Video
+Controls are on by default and width is 100%.
+
+#embed(http://techslides.com/demos/sample-videos/small.mp4 video)
+
+### Audio
+Controls are on by default.
+
+#embed(http://techslides.com/demos/samples/sample.mp3 audio)

--- a/website/index.js
+++ b/website/index.js
@@ -134,6 +134,10 @@ new Docute({
           link: '/guide/plugin'
         },
         {
+          title: 'Embed',
+          link: '/guide/embed'
+        },
+        {
           title: 'Deployment',
           link: '/guide/deployment'
         }


### PR DESCRIPTION
#205
I added this into core plugins, and made a separate page in guides for docs.

It doesn't parse titles into sidebar since you'd have to sort out the order in which they should come, which the documentation will note as much. The controls for video/audio is a boolean attribute therefore it can't be overridden with additional attributes like controls='false', and it is set on by default.