### PR TITLE
Build a local search plugin

### DIFF
--- a/src/PluginAPI.js
+++ b/src/PluginAPI.js
@@ -58,4 +58,33 @@ export default class PluginAPI {
     this.search.enabled = true
     return this
   }
+
+  enableLocalSearch() {
+    const entries = []
+    for (let x = 0; x < this.store.getters.sidebar.length; x++) {
+      const obj = this.store.getters.sidebar[x]
+      if (obj && obj.title && obj.link) {
+        entries.push({
+          title: obj.title,
+          link: obj.link
+        })
+      }
+      if (obj.children) {
+        for (let y = 0; y < obj.children.length; y++) {
+          const obj2 = obj.children[y]
+          entries.push(obj2)
+        }
+      }
+    }
+
+    this.search = {
+      handler: keyword => {
+        return entries.filter(value =>
+          value.title.toLowerCase().includes(keyword.toLowerCase())
+        )
+      }
+    }
+    this.search.enabled = true
+    return this
+  }
 }

--- a/src/plugins/search/localSearch.js
+++ b/src/plugins/search/localSearch.js
@@ -1,0 +1,6 @@
+export default {
+  name: 'localSearch',
+  extend(api) {
+    api.enableLocalSearch()
+  }
+}


### PR DESCRIPTION
Closes #21

Users have to add localSearch to their plugins to enable it.
It loops through all items in the Navbar and makes them searchable.